### PR TITLE
Fix server loan same IP check

### DIFF
--- a/src/main/java/red/man10/man10bank/loan/ServerLoan.kt
+++ b/src/main/java/red/man10/man10bank/loan/ServerLoan.kt
@@ -169,6 +169,11 @@ object ServerLoan {
             return
         }
 
+        if (borrowedSubAccount(p.uniqueId)){
+            sendMsg(p,"§c同一IPの他プレイヤーがすでに借入を行っています")
+            return
+        }
+
         val max = getMaximumLoanAmount(p)
         val borrowing = getBorrowingAmount(p)
 
@@ -204,6 +209,11 @@ object ServerLoan {
 
     @Synchronized
     fun borrow(p:Player, amount:Double){
+
+        if (borrowedSubAccount(p.uniqueId)){
+            sendMsg(p,"§c同一IPの他プレイヤーがすでに借入を行っています")
+            return
+        }
 
         val mysql = MySQLManager(plugin,"Man10ServerLoan")
 


### PR DESCRIPTION
## Summary
- prevent borrowing if a player on the same IP already has a server loan

## Testing
- `gradle test` *(fails: Plugin not found due to lack of network access)*