### PR TITLE
Update packaging for Paper plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '1.7.10'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 group = 'red.man10'
@@ -23,7 +24,7 @@ dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly "com.github.MilkBowl:VaultAPI:1.7"
     compileOnly fileTree(dir: 'libs', include: '*.jar')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 def targetJavaVersion = 17
@@ -52,11 +53,17 @@ processResources {
 }
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 compileTestKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
+
+shadowJar {
+    archiveClassifier.set('')
+}
+
+build.dependsOn shadowJar


### PR DESCRIPTION
## Summary
- add the Shadow plugin and switch Kotlin stdlib to `compileOnly`
- produce plugin JAR via `shadowJar`
- target Java 17 in Kotlin compiler

## Testing
- `gradle build` *(fails: Plugin org.jetbrains.kotlin.jvm not found)*