### PR TITLE
Split cheque commands from BankCommand

### DIFF
--- a/src/main/java/red/man10/man10bank/Man10Bank.kt
+++ b/src/main/java/red/man10/man10bank/Man10Bank.kt
@@ -21,6 +21,7 @@ import red.man10.man10bank.atm.ATMData
 import red.man10.man10bank.atm.ATMInventory
 import red.man10.man10bank.atm.ATMListener
 import red.man10.man10bank.cheque.Cheque
+import red.man10.man10bank.cheque.ChequeCommand
 import red.man10.man10bank.command.BankCommand
 import red.man10.man10bank.history.EstateData
 import red.man10.man10bank.loan.*
@@ -99,9 +100,12 @@ class Man10Bank : JavaPlugin(),Listener {
 
         bankCommand = BankCommand(this)
         val executor = bankCommand
-        arrayOf("bal","balance","money","bank","mbal","atm","mpay","mbaltop","mloantop","pay","deposit","withdraw","mchequeop","mcheque","ballog").forEach {
+        arrayOf("bal","balance","money","bank","mbal","atm","mpay","mbaltop","mloantop","pay","deposit","withdraw","ballog").forEach {
             getCommand(it)?.setExecutor(executor)
         }
+
+        val chequeCommand = ChequeCommand(this)
+        arrayOf("mchequeop", "mcheque").forEach { getCommand(it)?.setExecutor(chequeCommand) }
 
     }
 

--- a/src/main/java/red/man10/man10bank/cheque/ChequeCommand.kt
+++ b/src/main/java/red/man10/man10bank/cheque/ChequeCommand.kt
@@ -1,0 +1,63 @@
+package red.man10.man10bank.cheque
+
+import org.bukkit.Bukkit
+import org.bukkit.command.Command
+import org.bukkit.command.CommandExecutor
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+import red.man10.man10bank.Man10Bank
+import red.man10.man10bank.Man10Bank.Companion.ISSUE_CHEQUE
+import red.man10.man10bank.Man10Bank.Companion.OP
+import red.man10.man10bank.Man10Bank.Companion.sendMsg
+import kotlin.math.floor
+import java.text.Normalizer
+
+class ChequeCommand(private val plugin: Man10Bank) : CommandExecutor {
+
+    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
+        when(label){
+            "mchequeop" -> {
+                if (sender !is Player) return false
+                if (!sender.hasPermission(OP)) return false
+                if (args.isEmpty()) return false
+
+                val amount = args[0].toDoubleOrNull() ?: return false
+                val note = if (args.size > 1) args[1] else null
+
+                Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+                    sendMsg(sender, "§a§l銀行に問い合わせ中...§k§lXX")
+                    Cheque.createCheque(sender, amount, note, true)
+                })
+                return true
+            }
+            "mcheque" -> {
+                if (sender !is Player) return false
+                if (!sender.hasPermission(ISSUE_CHEQUE)) {
+                    sendMsg(sender, "§cあなたは小切手を発行する権限がありません")
+                    return false
+                }
+                if (args.isEmpty()) {
+                    sendMsg(sender, "§e§l/mcheque <金額> <メモ>")
+                    return true
+                }
+                val amount = floor(zenkakuToHankaku(args[0]))
+                if (amount <= 0.0) {
+                    sendMsg(sender, "金額を1以上にしてください")
+                    return true
+                }
+                val note = if (args.size > 1) args[1] else null
+                Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
+                    sendMsg(sender, "§a§l銀行に問い合わせ中...§k§lXX")
+                    Cheque.createCheque(sender, amount, note, false)
+                })
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun zenkakuToHankaku(number: String): Double {
+        val normalize = Normalizer.normalize(number, Normalizer.Form.NFKC)
+        return normalize.toDoubleOrNull() ?: -1.0
+    }
+}

--- a/src/main/java/red/man10/man10bank/command/BankCommand.kt
+++ b/src/main/java/red/man10/man10bank/command/BankCommand.kt
@@ -12,7 +12,6 @@ import red.man10.man10bank.*
 import red.man10.man10bank.Man10Bank.Companion.*
 import red.man10.man10bank.atm.ATMData
 import red.man10.man10bank.atm.ATMInventory
-import red.man10.man10bank.cheque.Cheque
 import red.man10.man10bank.history.EstateData
 import red.man10.man10bank.loan.*
 import red.man10.man10score.ScoreDatabase
@@ -31,49 +30,7 @@ class BankCommand(private val plugin: Man10Bank) : CommandExecutor {
     
             when(label){
     
-                "mchequeop" ->{//mchequeop amount <memo>
-                    if (sender !is Player)return false
-                    if (!sender.hasPermission(OP))return false
-    
-                    val amount = args[0].toDoubleOrNull()?:return false
-                    val note = if (args.size>1)args[1] else null
-    
-                    Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
-                        sendMsg(sender,"§a§l銀行に問い合わせ中...§k§lXX")
-                        Cheque.createCheque(sender,amount,note,true)
-                    })
-    
-                    return true
-                }
-    
-                "mcheque" ->{//mcheque amount <memo>
-                    if (sender !is Player)return false
-                    if (!sender.hasPermission(ISSUE_CHEQUE)){
-                        sendMsg(sender,"§cあなたは小切手を発行する権限がありません")
-                        return false
-                    }
-    
-                    if (args.isEmpty()){
-                        sendMsg(sender,"§e§l/mcheque <金額> <メモ>")
-                        return true
-                    }
-    
-                    val amount = floor(ZenkakuToHankaku(args[0]))
-    
-                    if (amount<=0.0){
-                        sendMsg(sender,"金額を1以上にしてください")
-                        return true
-                    }
-    
-                    val note = if (args.size>1)args[1] else null
-    
-                    Bukkit.getScheduler().runTaskAsynchronously(plugin, Runnable {
-                        sendMsg(sender,"§a§l銀行に問い合わせ中...§k§lXX")
-                        Cheque.createCheque(sender,amount,note,false)
-                    })
-    
-                    return true
-                }
+
     
                 "atm" ->{
                     if (sender !is Player)return false


### PR DESCRIPTION
## Summary
- add `ChequeCommand` to handle `/mcheque` and `/mchequeop`
- register new command handler in `Man10Bank`
- remove cheque logic from `BankCommand`

## Testing
- `./gradlew test` *(fails: no tests defined)*
- `./gradlew build` *(fails: no network access)*